### PR TITLE
build config adding wait tolerance

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -247,6 +247,10 @@
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
+				<configuration>
+	              <wait>1000</wait>
+	              <maxAttempts>180</maxAttempts>
+			     </configuration>
 				<executions>
 					<execution>
 						<id>build-info</id>


### PR DESCRIPTION
Adding configuration to spring boot plugin to be more tolerant of slower build times which otherwise can cause remote deployment failures e.g. jenkins

My Jenkins regression pipe is failing due to longer than usual build times:
![image](https://user-images.githubusercontent.com/5505730/65189514-2f210a00-da3f-11e9-96d1-7ce9220e345b.png)

This must be the default wait period when none is defined.

Found proposed solution here:
https://stackoverflow.com/a/42781794/5012320